### PR TITLE
Fix Gemini history regex

### DIFF
--- a/src/server/services/tokenService.js
+++ b/src/server/services/tokenService.js
@@ -94,7 +94,8 @@ class TokenService {
    * Split Gemini format history into segments
    */
   splitGeminiSegments(chatHistory) {
-    const segmentRegex = /(?:System Prompt:|User Prompt:|Response:)([^:]+)(?=System Prompt:|User Prompt:|Response:|$)/g;
+    // Capture everything between section labels including newlines and colons
+    const segmentRegex = /(?:System Prompt:|User Prompt:|Response:)([\s\S]*?)(?=System Prompt:|User Prompt:|Response:|$)/g;
     const matches = [];
     let match;
     


### PR DESCRIPTION
## Summary
- fix Gemini segment parsing regex to handle colons and newlines

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68735fb6ca348332a1e6f63cfa8310b0